### PR TITLE
Put mosquitto conf in cond.d folder

### DIFF
--- a/opt/www/reregister.cgi
+++ b/opt/www/reregister.cgi
@@ -12,7 +12,7 @@ echo "<pre>"
 
 echo "<b>Re-registering</b>"
 iotopen-verify
-cp /etc/iot-open/mosquitto.conf /etc/mosquitto/
+cp /etc/iot-open/mosquitto.conf /etc/mosquitto/conf.d/iotopen.conf
 /etc/init.d/mosquitto restart
 
 # TODO: Edged restart


### PR DESCRIPTION
Mosquitto in debian now loads all conf files in `/etc/mosquitto/conf.d/` by default. This moves the mosquitto config to that folder instead. 